### PR TITLE
CI: Use CrateDB nightly again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        cratedb-version: ["5.5.3"]
+        cratedb-version: ["nightly"]
       fail-fast: false
 
     services:


### PR DESCRIPTION
## About

Now that https://github.com/crate/crate/pull/15408 has landed, use CrateDB nightly again.
