### PR TITLE
Fix software tests, the recently added `pytest.skip` was wrong

### DIFF
--- a/tests/test_cratedb_pandas_read.py
+++ b/tests/test_cratedb_pandas_read.py
@@ -1,3 +1,5 @@
+import sys
+
 import pandas as pd
 import pytest
 import sqlalchemy as sa
@@ -8,7 +10,8 @@ REFERENCE_FRAME = pd.DataFrame.from_records([{"mountain": "Mont Blanc", "height"
 SQL_SELECT_STATEMENT = "SELECT mountain, height FROM sys.summits ORDER BY height DESC LIMIT 1;"
 
 
-pytest.skip("Does not work on Python 3.7", allow_module_level=True)
+if sys.version_info < (3, 8):
+    pytest.skip("Does not work on Python 3.7", allow_module_level=True)
 
 
 def test_crate_read_sql(cratedb_http_host, cratedb_http_port):

--- a/tests/test_cratedb_pandas_write.py
+++ b/tests/test_cratedb_pandas_write.py
@@ -1,3 +1,5 @@
+import sys
+
 import pandas as pd
 import pytest
 import sqlalchemy as sa
@@ -9,7 +11,8 @@ SQL_SELECT_STATEMENT = "SELECT * FROM doc.foo;"
 SQL_REFRESH_STATEMENT = "REFRESH TABLE doc.foo;"
 
 
-pytest.skip("Does not work on Python 3.7", allow_module_level=True)
+if sys.version_info < (3, 8):
+    pytest.skip("Does not work on Python 3.7", allow_module_level=True)
 
 
 def test_crate_to_sql(cratedb_http_host, cratedb_http_port):


### PR DESCRIPTION
## About

GH-31 was not quite right on two spots. This patch fixes them.
