### PR TITLE
Add software tests using Polars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ release = [
 test = [
   "crate[sqlalchemy]",
   "pandas<2.3",
+  "polars[pyarrow]<0.21",
   "pytest<9",
   "pytest-asyncio<1",
   "pytest-cov<5",

--- a/tests/test_cratedb_polars_read.py
+++ b/tests/test_cratedb_polars_read.py
@@ -1,0 +1,43 @@
+import sys
+
+import polars as pl
+import pytest
+import sqlalchemy as sa
+from polars.testing import assert_frame_equal
+
+REFERENCE_FRAME = pl.from_records([{"mountain": "Mont Blanc", "height": 4808}])
+SQL_SELECT_STATEMENT = "SELECT mountain, height FROM sys.summits ORDER BY height DESC LIMIT 1;"
+
+
+if sys.version_info < (3, 8):
+    pytest.skip("Does not work on Python 3.7", allow_module_level=True)
+
+
+def test_crate_read_sql(cratedb_http_host, cratedb_http_port):
+    engine = sa.create_engine(
+        url=f"crate://{cratedb_http_host}:{cratedb_http_port}",
+        echo=True,
+    )
+    conn = engine.connect()
+    df = pl.read_database(
+        query=SQL_SELECT_STATEMENT,
+        connection=conn,
+        schema_overrides={"value": pl.Utf8},
+    )
+    assert_frame_equal(df, REFERENCE_FRAME)
+
+
+def test_psycopg_read_sql(cratedb_psql_host, cratedb_psql_port):
+    engine = sa.create_engine(
+        url=f"postgresql+psycopg_relaxed://crate@{cratedb_psql_host}:{cratedb_psql_port}",
+        isolation_level="AUTOCOMMIT",
+        use_native_hstore=False,
+        echo=True,
+    )
+    conn = engine.connect()
+    df = pl.read_database(
+        query=SQL_SELECT_STATEMENT,
+        connection=conn,
+        schema_overrides={"value": pl.Utf8},
+    )
+    assert_frame_equal(df, REFERENCE_FRAME)


### PR DESCRIPTION
## About
Following up on validating [pandas](https://pandas.pydata.org/), this patch starts validating the [Polars](https://pola.rs/) DataFrame library.

- GH-31

## Details
Polars does not support writing to databases yet, nor does it support [SQLAlchemy's AsyncEngine](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html). So, this exercises [`pl.read_database()`](https://docs.pola.rs/user-guide/io/database/) only, together with the `crate` and `postgresql+psycopg_relaxed` dialects, using [urllib3](https://urllib3.readthedocs.io/) resp. [Psycopg3](https://www.psycopg.org/psycopg3/docs/).

## References
- https://github.com/crate/crate/issues/12952#issuecomment-1862944511
- https://github.com/crate-workbench/sqlalchemy-cratedb/pull/11

/cc @surister, @SStorm
