### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,12 +77,12 @@ release = [
   "twine<6",
 ]
 test = [
-  "crate[sqlalchemy]",
   "pandas<2.3",
   "polars[pyarrow]<0.21",
   "pytest<9",
   "pytest-asyncio<1",
   "pytest-cov<6",
+  "sqlalchemy-cratedb",
 ]
 [project.urls]
 changelog = "https://github.com/pyveci/sqlalchemy-postgresql-relaxed/blob/main/CHANGES.rst"


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch intends to accompany the migration.

## Details
The new canonical package for the SQLAlchemy CrateDB dialect on PyPI is:

> https://pypi.org/project/sqlalchemy-cratedb/
