### PR TITLE
CI: Verify support on Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: ["ubuntu-22.04"]
         cratedb-version: ["nightly"]
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-22.04"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         cratedb-version: ["nightly"]
       fail-fast: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Communications",
   "Topic :: Database",
   "Topic :: Documentation",
@@ -78,7 +79,7 @@ optional-dependencies.release = [
 ]
 optional-dependencies.test = [
   "pandas<2.3",
-  "polars[pyarrow]<1.10",
+  "polars[pyarrow]<1.10; python_version<'3.13'",
   "pytest<9",
   "pytest-asyncio<1",
   "pytest-cov<6",

--- a/tests/test_cratedb_polars_read.py
+++ b/tests/test_cratedb_polars_read.py
@@ -1,7 +1,9 @@
+# ruff: noqa: E402
 import sys
 
-import polars as pl
 import pytest
+
+pl = pytest.importorskip("polars")
 import sqlalchemy as sa
 from polars.testing import assert_frame_equal
 


### PR DESCRIPTION
## About
[Python 3.13.0](https://www.python.org/downloads/release/python-3130/) has been released on Oct. 7, 2024. This PR intends to add CI verification.

## References
- https://github.com/crate/crate-python/pull/653
- https://github.com/crate/sqlalchemy-cratedb/pull/167
